### PR TITLE
[CompressedFluids]Fix ingredient copy method

### DIFF
--- a/CompressedFluids/prototypes/technology/compressor.lua
+++ b/CompressedFluids/prototypes/technology/compressor.lua
@@ -17,7 +17,7 @@ data:extend{
     unit =
     {
       count = 250,
-      ingredients = data.raw.technology["engine"].unit.ingredients,
+      ingredients = table.deepcopy(data.raw.technology["engine"].unit.ingredients),
       time = 2 * data.raw.technology["engine"].unit.time,
     },
     upgrade = false,


### PR DESCRIPTION
Use 'table.deepcopy()' to assign compressor's technology ingredients instead of referencing compressor & engine to the same table